### PR TITLE
feat: VOL-3691 switch to Psr Container

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
         "laminas/laminas-mvc": "^3.3",
         "laminas/laminas-session": "^2.8.7",
         "laminas/laminas-console": "^2.7",
-        "laminas/laminas-stdlib": "^3.0"
+        "laminas/laminas-stdlib": "^3.0",
+        "psr/container": "^1.1|^2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Helper/LogError.php
+++ b/src/Helper/LogError.php
@@ -2,7 +2,7 @@
 
 namespace Olcs\Logging\Helper;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use Laminas\Log\LoggerAwareTrait;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 

--- a/src/Helper/LogException.php
+++ b/src/Helper/LogException.php
@@ -2,7 +2,7 @@
 
 namespace Olcs\Logging\Helper;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use Laminas\Log\LoggerAwareTrait;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 

--- a/src/Listener/LogError.php
+++ b/src/Listener/LogError.php
@@ -2,7 +2,7 @@
 
 namespace Olcs\Logging\Listener;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use Laminas\EventManager\EventManagerInterface;
 use Laminas\EventManager\ListenerAggregateInterface;
 use Laminas\EventManager\ListenerAggregateTrait;

--- a/src/Listener/LogRequest.php
+++ b/src/Listener/LogRequest.php
@@ -2,7 +2,7 @@
 
 namespace Olcs\Logging\Listener;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use Laminas\EventManager\EventManagerInterface;
 use Laminas\EventManager\ListenerAggregateInterface;
 use Laminas\EventManager\ListenerAggregateTrait;

--- a/src/Log/Processor/CorrelationIdFactory.php
+++ b/src/Log/Processor/CorrelationIdFactory.php
@@ -2,7 +2,7 @@
 
 namespace Olcs\Logging\Log\Processor;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 
 /**

--- a/test/Helper/LogErrorTest.php
+++ b/test/Helper/LogErrorTest.php
@@ -2,7 +2,7 @@
 
 namespace OlcsTest\Logging\Helper;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use Olcs\Logging\Helper\LogError;
 use Mockery as m;
 use Mockery\Adapter\Phpunit\MockeryTestCase as TestCase;

--- a/test/Helper/LogExceptionTest.php
+++ b/test/Helper/LogExceptionTest.php
@@ -2,7 +2,7 @@
 
 namespace OlcsTest\Logging\Helper;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use Mockery\Adapter\Phpunit\MockeryTestCase as TestCase;
 use Olcs\Logging\Helper\LogException;
 use Mockery as m;

--- a/test/Listener/LogErrorTest.php
+++ b/test/Listener/LogErrorTest.php
@@ -2,7 +2,7 @@
 
 namespace OlcsTest\Logging\Listener;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use Mockery\Adapter\Phpunit\MockeryTestCase as TestCase;
 use Mockery as m;
 use Olcs\Logging\Helper\LogException;

--- a/test/Listener/LogRequestTest.php
+++ b/test/Listener/LogRequestTest.php
@@ -2,7 +2,7 @@
 
 namespace OlcsTest\Logging\Listener;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use Laminas\Console\Request;
 use Laminas\ServiceManager\ServiceLocatorInterface;
 use Mockery\Adapter\Phpunit\MockeryTestCase as TestCase;


### PR DESCRIPTION
BREAKING CHANGE: interop/container no longer supported

## Description

container/interop has been swapped out for the PSR version

Related issue: [VOL-3691](https://dvsa.atlassian.net/browse/VOL-3691)