### PR TITLE
feat: always log HTTP errors at `DEBUG` level

### DIFF
--- a/src/Listener/LogRequest.php
+++ b/src/Listener/LogRequest.php
@@ -105,13 +105,7 @@ class LogRequest implements ListenerAggregateInterface, FactoryInterface
                 'status' => $response->getReasonPhrase(),
             ];
 
-            if ($response->isServerError()) {
-                $this->getLogger()->err('Request completed', ['data' => $data]);
-            } elseif ($response->isClientError()) {
-                $this->getLogger()->info('Request completed', ['data' => $data]);
-            } else {
-                $this->getLogger()->debug('Request completed', ['data' => $data]);
-            }
+            $this->getLogger()->debug('Request completed', ['data' => $data]);
         }
     }
 

--- a/src/Log/Logger.php
+++ b/src/Log/Logger.php
@@ -141,15 +141,7 @@ class Logger
      */
     public static function logResponse($status, $message, $extra = array())
     {
-        if ($status < 400) {
-            $priority = \Laminas\Log\Logger::DEBUG;
-        } elseif ($status < 500) {
-            $priority = \Laminas\Log\Logger::INFO;
-        } else {
-            $priority = \Laminas\Log\Logger::ERR;
-        }
-
-        return self::$logger->log($priority, $message, $extra);
+        return self::$logger->log(\Laminas\Log\Logger::DEBUG, $message, $extra);
     }
 
     /**

--- a/test/Listener/LogRequestTest.php
+++ b/test/Listener/LogRequestTest.php
@@ -136,8 +136,6 @@ class LogRequestTest extends TestCase
         $mockResponse = m::mock('Laminas\Http\Response');
         $mockResponse->shouldReceive('getStatusCode')->andReturn('200');
         $mockResponse->shouldReceive('getReasonPhrase')->andReturn('OK');
-        $mockResponse->shouldReceive('isServerError')->andReturn(false);
-        $mockResponse->shouldReceive('isClientError')->andReturn(false);
 
         $mockRequest = m::mock('Laminas\Http\Request');
         $mockRequest->shouldReceive('getUriString')->andReturn('http://foo.com/bar');
@@ -148,57 +146,6 @@ class LogRequestTest extends TestCase
 
         $mockLog = $this->getMockLog();
         $mockLog->shouldReceive('debug')->with('Request completed', ['data' => $params]);
-
-        $sut = new LogRequest();
-        $sut->setLogger($mockLog);
-        $sut->onDispatchEnd($mockEvent);
-    }
-
-    public function testHttpOnDispatchEndClientError()
-    {
-        $params = ['request' => 'http://foo.com/bar', 'code' => '403', 'status' => 'Foo'];
-
-        $mockResponse = m::mock('Laminas\Http\Response');
-        $mockResponse->shouldReceive('getStatusCode')->andReturn('403');
-        $mockResponse->shouldReceive('getReasonPhrase')->andReturn('Foo');
-        $mockResponse->shouldReceive('isServerError')->andReturn(false);
-        $mockResponse->shouldReceive('isClientError')->andReturn(true);
-
-        $mockRequest = m::mock('Laminas\Http\Request');
-        $mockRequest->shouldReceive('getUriString')->andReturn('http://foo.com/bar');
-
-        $mockEvent = m::mock('Laminas\Mvc\MvcEvent');
-        $mockEvent->shouldReceive('getResponse')->andReturn($mockResponse);
-        $mockEvent->shouldReceive('getRequest')->atLeast()->once()->andReturn($mockRequest);
-
-        $mockLog = $this->getMockLog();
-        $mockLog->shouldReceive('info')->with('Request completed', ['data' => $params]);
-
-        $sut = new LogRequest();
-        $sut->setLogger($mockLog);
-        $sut->onDispatchEnd($mockEvent);
-    }
-
-    public function testHttpOnDispatchEndServerError()
-    {
-        $params = ['request' => 'http://foo.com/bar', 'code' => '500', 'status' => 'Foo'];
-
-        $mockResponse = m::mock('Laminas\Http\Response');
-        $mockResponse->shouldReceive('getStatusCode')->andReturn('500');
-        $mockResponse->shouldReceive('getReasonPhrase')->andReturn('Foo');
-        $mockResponse->shouldReceive('isServerError')->andReturn(true);
-        $mockResponse->shouldReceive('isClientError')->andReturn(false);
-        $mockResponse->shouldReceive('getBody')->andReturn('BODY');
-
-        $mockRequest = m::mock('Laminas\Http\Request');
-        $mockRequest->shouldReceive('getUriString')->andReturn('http://foo.com/bar');
-
-        $mockEvent = m::mock('Laminas\Mvc\MvcEvent');
-        $mockEvent->shouldReceive('getResponse')->andReturn($mockResponse);
-        $mockEvent->shouldReceive('getRequest')->atLeast()->once()->andReturn($mockRequest);
-
-        $mockLog = $this->getMockLog();
-        $mockLog->shouldReceive('err')->with('Request completed', ['data' => $params]);
 
         $sut = new LogRequest();
         $sut->setLogger($mockLog);

--- a/test/Log/LoggerTest.php
+++ b/test/Log/LoggerTest.php
@@ -103,20 +103,6 @@ class LoggerTest extends MockeryTestCase
         Logger::logResponse(200, 'foo', ['foo' => 'bar']);
     }
 
-    public function testLogResponseClientError()
-    {
-        $this->logger->shouldReceive('log')->once()->with(6, 'foo', ['foo' => 'bar']);
-
-        Logger::logResponse(400, 'foo', ['foo' => 'bar']);
-    }
-
-    public function testLogResponseServerError()
-    {
-        $this->logger->shouldReceive('log')->once()->with(3, 'foo', ['foo' => 'bar']);
-
-        Logger::logResponse(500, 'foo', ['foo' => 'bar']);
-    }
-
     public function testLogException()
     {
         $e = new \Exception('Foo', 200);


### PR DESCRIPTION
## Description

To reduce log duplication and volume, this ticket updates HTTP relates issues to be logged at `DEBUG` rather than `ERR`, `INFO` & `DEBUG`

Related issue: https://dvsa.atlassian.net/browse/VOL-4618

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
