### PR TITLE
chore!: bump various deps and php versions, fix static analysis VOL-6497

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,17 +9,18 @@ jobs:
   security:
     uses: dvsa/.github/.github/workflows/php-library-security.yml@main
     with:
-      php-versions: "[\"8.0\", \"8.1\", \"8.2\", \"8.3\"]"
+      php-versions: "[\"8.2\", \"8.3\"]"
     secrets:
       SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 
   static-analysis:
     uses: dvsa/.github/.github/workflows/php-library-static.yml@main
     with:
-      php-version: '8.0'
+      php-version: '8.3'
+      stability: '["prefer-stable"]'
 
   tests:
     uses: dvsa/.github/.github/workflows/php-library-tests.yml@main
     with:
-      php-versions: "[\"8.0\", \"8.1\", \"8.2\", \"8.3\"]"
+      php-versions: "[\"8.2\", \"8.3\"]"
       fail-fast: false

--- a/composer.json
+++ b/composer.json
@@ -4,13 +4,13 @@
     "license": "MIT",
     "require": {
         "ext-json": "*",
-        "php": "^7.4|^8.0",
+        "php": "~8.2.0 || ~8.3.0",
         "psr/log": "^1.0",
-        "laminas/laminas-log": "^2.12",
-        "laminas/laminas-eventmanager": "^3.0",
-        "laminas/laminas-mvc": "^3.3",
-        "laminas/laminas-session": "^2.8.7",
-        "laminas/laminas-stdlib": "^3.0",
+        "laminas/laminas-log": "^2.17.1",
+        "laminas/laminas-eventmanager": "^3.14",
+        "laminas/laminas-mvc": "^3.8",
+        "laminas/laminas-session": "^2.21",
+        "laminas/laminas-stdlib": "^3.20",
         "psr/container": "^1.1|^2"
     },
     "autoload": {
@@ -27,8 +27,8 @@
         "phpunit/phpunit": "^9.6",
         "mockery/mockery": "^1.6",
         "johnkary/phpunit-speedtrap": "^4.0",
-        "bamarni/composer-bin-plugin": "^1.8",
-        "phpstan/phpstan-mockery": "^1.1"
+        "bamarni/composer-bin-plugin": "^1.8.2",
+        "phpstan/phpstan-mockery": "^2.0"
     },
     "config": {
         "allow-plugins": {

--- a/src/Helper/LogError.php
+++ b/src/Helper/LogError.php
@@ -6,14 +6,11 @@ use Psr\Container\ContainerInterface;
 use Laminas\Log\LoggerAwareTrait;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 
-/**
- * Class LogError
- * @package Olcs\Logging\Helper
- */
 class LogError implements FactoryInterface
 {
     use LoggerAwareTrait;
 
+    #[\Override]
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null): LogError
     {
         $this->setLogger($container->get('Logger'));

--- a/src/Helper/LogException.php
+++ b/src/Helper/LogException.php
@@ -6,10 +6,6 @@ use Psr\Container\ContainerInterface;
 use Laminas\Log\LoggerAwareTrait;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 
-/**
- * Class LogException
- * @package Olcs\Logging\Helper
- */
 class LogException implements FactoryInterface
 {
     use LoggerAwareTrait;
@@ -40,6 +36,7 @@ class LogException implements FactoryInterface
         );
     }
 
+    #[\Override]
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null): LogException
     {
         $this->setLogger($container->get('Logger'));

--- a/src/Listener/LogError.php
+++ b/src/Listener/LogError.php
@@ -2,6 +2,7 @@
 
 namespace Olcs\Logging\Listener;
 
+use Olcs\Logging\Log\Processor\RequestId;
 use Psr\Container\ContainerInterface;
 use Laminas\EventManager\EventManagerInterface;
 use Laminas\EventManager\ListenerAggregateInterface;
@@ -40,18 +41,20 @@ class LogError implements ListenerAggregateInterface, FactoryInterface
     /**
      * {@inheritdoc}
      */
+    #[\Override]
     public function attach(EventManagerInterface $events, $priority = 1)
     {
         $this->listeners[] = $events->attach(MvcEvent::EVENT_DISPATCH_ERROR, array($this, 'onDispatchError'), 0);
         $this->listeners[] = $events->attach(MvcEvent::EVENT_RENDER_ERROR, array($this, 'onDispatchError'), 0);
     }
 
+    #[\Override]
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null): LogError
     {
         $this->setLogExceptionHelper($container->get('Olcs\Logging\Helper\LogException'));
         $this->setIdentifier(
             $container->get('LogProcessorManager')
-                ->get(\Olcs\Logging\Log\Processor\RequestId::class)
+                ->get(RequestId::class)
                 ->getIdentifier()
         );
 

--- a/src/Listener/LogRequest.php
+++ b/src/Listener/LogRequest.php
@@ -23,6 +23,7 @@ class LogRequest implements ListenerAggregateInterface, FactoryInterface
     /**
      * {@inheritdoc}
      */
+    #[\Override]
     public function attach(EventManagerInterface $events, $priority = 1)
     {
         $this->listeners[] = $events->attach(MvcEvent::EVENT_ROUTE, array($this, 'onRoute'), 10000);
@@ -30,6 +31,7 @@ class LogRequest implements ListenerAggregateInterface, FactoryInterface
         $this->listeners[] = $events->attach(MvcEvent::EVENT_FINISH, array($this, 'onDispatchEnd'), 10000);
     }
 
+    #[\Override]
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null): LogRequest
     {
         $this->setLogger($container->get('Logger'));

--- a/src/Log/Formatter/Standard.php
+++ b/src/Log/Formatter/Standard.php
@@ -32,10 +32,9 @@ class Standard implements FormatterInterface
      * Format a log event
      *
      * @param array $event Array of event data
-     *
-     * @return string
      */
-    public function format($event)
+    #[\Override]
+    public function format($event): string|false
     {
         $event = $this->laminasBaseFormatter->format($event);
 
@@ -80,6 +79,7 @@ class Standard implements FormatterInterface
      *
      * {@inheritDoc}
      */
+    #[\Override]
     public function getDateTimeFormat()
     {
         return $this->dateTimeFormat;
@@ -90,6 +90,7 @@ class Standard implements FormatterInterface
      *
      * {@inheritDoc}
      */
+    #[\Override]
     public function setDateTimeFormat($dateTimeFormat)
     {
         $this->dateTimeFormat = (string) $dateTimeFormat;

--- a/src/Log/Formatter/StandardFactory.php
+++ b/src/Log/Formatter/StandardFactory.php
@@ -11,9 +11,8 @@ class StandardFactory implements FactoryInterface
 {
     /**
      * @param string $requestedName
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
+    #[\Override]
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null): Standard
     {
         /** @var FormatterPluginManager $logFormatterManager */

--- a/src/Log/LaminasLogPsr3Adapter.php
+++ b/src/Log/LaminasLogPsr3Adapter.php
@@ -40,6 +40,7 @@ class LaminasLogPsr3Adapter extends AbstractPsrLogger
      *
      * @return LaminasLogger
      */
+    #[\Override]
     public function log($level, $message, array $context = []): LaminasLogger
     {
         return $this->log->log($this->map[$level], $message, $context);

--- a/src/Log/Processor/CorrelationId.php
+++ b/src/Log/Processor/CorrelationId.php
@@ -32,6 +32,7 @@ class CorrelationId implements ProcessorInterface
      *
      * @return array
      */
+    #[\Override]
     public function process(array $event)
     {
         $event['extra']['correlationId'] = $this->getIdentifier();

--- a/src/Log/Processor/CorrelationIdFactory.php
+++ b/src/Log/Processor/CorrelationIdFactory.php
@@ -5,9 +5,6 @@ namespace Olcs\Logging\Log\Processor;
 use Psr\Container\ContainerInterface;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 
-/**
- * CorrelationIdFactory
- */
 class CorrelationIdFactory implements FactoryInterface
 {
     /**
@@ -16,8 +13,8 @@ class CorrelationIdFactory implements FactoryInterface
      * @param array|null $options
      *
      * @return CorrelationId
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
+    #[\Override]
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null): CorrelationId
     {
         return new CorrelationId(

--- a/src/Log/Processor/HidePassword.php
+++ b/src/Log/Processor/HidePassword.php
@@ -16,11 +16,9 @@ class HidePassword implements ProcessorInterface
 
     /**
      * Processes log event and removed any password
-     *
-     * @param  array $event
-     * @return array
      */
-    public function process(array $event)
+    #[\Override]
+    public function process(array $event): array
     {
         // recurse through the event
         array_walk_recursive(

--- a/src/Log/Processor/Microtime.php
+++ b/src/Log/Processor/Microtime.php
@@ -12,11 +12,9 @@ class Microtime implements ProcessorInterface
 {
     /**
      * Processes a log message before it is given to the writers
-     *
-     * @param  array $event
-     * @return array
      */
-    public function process(array $event)
+    #[\Override]
+    public function process(array $event): array
     {
         $microtime = explode(' ', microtime());
         $event['microsecs'] = substr($microtime[0], 2, 6);

--- a/src/Log/Processor/RemoteIp.php
+++ b/src/Log/Processor/RemoteIp.php
@@ -8,26 +8,21 @@ use Laminas\Http\PhpEnvironment\RemoteAddress;
 class RemoteIp implements ProcessorInterface
 {
     /**
-     * @var RemoteAddress
+     * @var ?RemoteAddress
      */
     protected $remoteAddress;
 
     /**
      * Processes a log message before it is given to the writers
-     *
-     * @param  array $event
-     * @return array
      */
-    public function process(array $event)
+    #[\Override]
+    public function process(array $event): array
     {
         $event['extra']['remoteIp'] = $this->getRemoteAddress()->getIpAddress();
 
         return $event;
     }
 
-    /**
-     * @return RemoteAddress
-     */
     public function getRemoteAddress(): RemoteAddress
     {
         if (!$this->remoteAddress instanceof RemoteAddress) {

--- a/src/Log/Processor/RequestId.php
+++ b/src/Log/Processor/RequestId.php
@@ -15,6 +15,7 @@ class RequestId extends LaminasRequestId
      *
      * @return string
      */
+    #[\Override]
     public function getIdentifier()
     {
         return parent::getIdentifier();

--- a/src/Log/Processor/SessionId.php
+++ b/src/Log/Processor/SessionId.php
@@ -6,13 +6,11 @@ use Laminas\Log\Processor\ProcessorInterface;
 use Laminas\Session\Container;
 use Laminas\Session\ManagerInterface as Manager;
 
-/**
- * Class SessionId
- * @package Olcs\Logging\Log\Processor
- */
 class SessionId implements ProcessorInterface
 {
-    /** @var Manager */
+    /**
+     * @var ?Manager
+     */
     protected $sessionManager;
 
     public function setSessionManager(Manager $sessionManager): SessionId
@@ -32,6 +30,7 @@ class SessionId implements ProcessorInterface
     /**
      * Processes a log message before it is given to the writers
      */
+    #[\Override]
     public function process(array $event): array
     {
         //This currently uses the php/laminas session id, could be altered to use open AM sessid when an auth solution has

--- a/src/Log/Processor/UserId.php
+++ b/src/Log/Processor/UserId.php
@@ -23,11 +23,9 @@ class UserId implements ProcessorInterface
 
     /**
      * Processes a log message before it is given to the writers
-     *
-     * @param  array $event
-     * @return array
      */
-    public function process(array $event)
+    #[\Override]
+    public function process(array $event): array
     {
         $event['extra']['userId'] = self::$userId;
         return $event;

--- a/src/Module.php
+++ b/src/Module.php
@@ -8,18 +8,9 @@ use Laminas\Mvc\MvcEvent;
 use Olcs\Logging\Log\Formatter\Standard;
 use Olcs\Logging\Log\Formatter\StandardFactory;
 
-/**
- * Class Module
- * @package Olcs\Logging
- */
 class Module
 {
-    /**
-     * Get config
-     *
-     * @return array
-     */
-    public function getConfig()
+    public function getConfig(): array
     {
         $logfile = sys_get_temp_dir() . '/olcs-' . PHP_SAPI . '-application.log';
 

--- a/test/ModuleTest.php
+++ b/test/ModuleTest.php
@@ -7,10 +7,6 @@ use Mockery\Adapter\Phpunit\MockeryTestCase;
 use Olcs\Logging\Module;
 use Mockery as m;
 
-/**
- * Class ModuleTest
- * @package OlcsTest\Logging
- */
 class ModuleTest extends MockeryTestCase
 {
     public function testGetConfig()
@@ -18,7 +14,6 @@ class ModuleTest extends MockeryTestCase
         $sut = new Module();
         $config = $sut->getConfig();
 
-        $this->assertIsArray($config);
         $this->assertArrayHasKey('log', $config);
     }
 

--- a/vendor-bin/phpcs/composer.json
+++ b/vendor-bin/phpcs/composer.json
@@ -1,6 +1,6 @@
 {
   "require-dev": {
-    "squizlabs/php_codesniffer": "^3.7",
+    "squizlabs/php_codesniffer": "^3.13",
     "dvsa/coding-standards": "^2.0"
   }
 }

--- a/vendor-bin/phpstan/composer.json
+++ b/vendor-bin/phpstan/composer.json
@@ -1,5 +1,5 @@
 {
   "require-dev": {
-    "phpstan/phpstan": "^1.10"
+    "phpstan/phpstan": "^2.1"
   }
 }

--- a/vendor-bin/psalm/composer.json
+++ b/vendor-bin/psalm/composer.json
@@ -1,5 +1,5 @@
 {
   "require-dev": {
-    "vimeo/psalm": "^5.15"
+    "vimeo/psalm": "^6.13"
   }
 }


### PR DESCRIPTION
## Description

Related issue: [VOL-6497](https://dvsa.atlassian.net/browse/VOL-6497)

- PHP composer version bumped to ~8.2.0 || ~8.3.0
- minimum versions bumped for Laminas packages
- PhpStan and Psalm both bumped to new major versions
- Static analysis now passing on PHP 8.3
- Code scanning and unit tests have dropped support for PHP 8.0 and 8.1

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?


[VOL-6497]: https://dvsa.atlassian.net/browse/VOL-6497?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ