### PR TITLE
fix: tolerate E_USER_ERROR as laminas-log did before monolog

### DIFF
--- a/src/Module.php
+++ b/src/Module.php
@@ -90,5 +90,49 @@ class Module
         ErrorHandler::register($logger);
 
         StaticLogger::setLogger($logger);
+
+        $this->registerUserErrorTolerance();
+    }
+
+    /**
+     * Tolerate E_USER_ERROR the way laminas-log did pre-monolog.
+     *
+     * laminas-view / guzzle __toString fallbacks call trigger_error(E_USER_ERROR)
+     * then return ''. laminas-log's handler returned true, so execution continued
+     * and pages still rendered. Monolog treats E_USER_ERROR as fatal and halts the
+     * request. We wrap Monolog's handler: log E_USER_ERROR with a triage tag and
+     * return true so execution continues; defer every other level to Monolog so its
+     * logging is unchanged. Only explicit trigger_error(E_USER_ERROR) is affected -
+     * real fatals are not catchable here and remain fatal.
+     */
+    private function registerUserErrorTolerance(): void
+    {
+        // Capture the currently-active handler (Monolog's) without disturbing it.
+        $previous = set_error_handler(static fn (): bool => false);
+        restore_error_handler();
+
+        set_error_handler($this->makeToleranceHandler($previous));
+    }
+
+    public function makeToleranceHandler(?callable $previous): callable
+    {
+        return static function (int $errno, string $message, string $file = '', int $line = 0) use ($previous): bool {
+            if ($errno === E_USER_ERROR) {
+                StaticLogger::err(
+                    'TOLERATED_USER_ERROR: ' . $message,
+                    [
+                        'tag' => 'tolerated-user-error',
+                        'errno' => $errno,
+                        'file' => $file,
+                        'line' => $line,
+                        'url' => $_SERVER['REQUEST_URI'] ?? null,
+                    ]
+                );
+
+                return true;
+            }
+
+            return is_callable($previous) ? (bool) $previous($errno, $message, $file, $line) : false;
+        };
     }
 }

--- a/test/ModuleTest.php
+++ b/test/ModuleTest.php
@@ -6,11 +6,21 @@ use Laminas\EventManager\EventInterface;
 use Mockery as m;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 use Monolog\Logger as MonologLogger;
+use Olcs\Logging\Log\Logger as StaticLogger;
 use Olcs\Logging\Log\Processor\HidePassword;
 use Olcs\Logging\Module;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 
 class ModuleTest extends MockeryTestCase
 {
+    protected function tearDown(): void
+    {
+        // Reset the static logger so a closed mock can't leak into later tests.
+        StaticLogger::setLogger(new NullLogger());
+        parent::tearDown();
+    }
+
     public function testGetConfig(): void
     {
         $sut = new Module();
@@ -55,5 +65,62 @@ class ModuleTest extends MockeryTestCase
             'allowFalse' => [1, ['log' => ['allowPasswordLogging' => false]]],
             'allowAmbiguous' => [0, ['log' => ['allowPasswordLogging' => 'somestring']]],
         ];
+    }
+
+    public function testToleranceHandlerToleratesUserError(): void
+    {
+        $logger = m::mock(LoggerInterface::class);
+        $logger->shouldReceive('error')
+            ->once()
+            ->with(
+                'TOLERATED_USER_ERROR: boom',
+                m::on(static fn (array $ctx): bool =>
+                    ($ctx['tag'] ?? null) === 'tolerated-user-error'
+                    && ($ctx['errno'] ?? null) === E_USER_ERROR
+                    && ($ctx['file'] ?? null) === '/x.php'
+                    && ($ctx['line'] ?? null) === 42)
+            );
+        StaticLogger::setLogger($logger);
+
+        $previousCalled = false;
+        $previous = static function () use (&$previousCalled): bool {
+            $previousCalled = true;
+            return false;
+        };
+
+        $handler = (new Module())->makeToleranceHandler($previous);
+        $result = $handler(E_USER_ERROR, 'boom', '/x.php', 42);
+
+        $this->assertTrue($result, 'E_USER_ERROR must be tolerated (return true) so execution continues');
+        $this->assertFalse($previousCalled, 'E_USER_ERROR is handled locally, not delegated to the previous handler');
+    }
+
+    public function testToleranceHandlerDelegatesOtherLevelsToPreviousHandler(): void
+    {
+        $logger = m::mock(LoggerInterface::class);
+        $logger->shouldReceive('error')->never();
+        StaticLogger::setLogger($logger);
+
+        $previousArgs = null;
+        $previous = static function (int $errno, string $message, string $file = '', int $line = 0) use (&$previousArgs): bool {
+            $previousArgs = [$errno, $message, $file, $line];
+            return true;
+        };
+
+        $handler = (new Module())->makeToleranceHandler($previous);
+        $result = $handler(E_USER_WARNING, 'warn', '/y.php', 7);
+
+        $this->assertTrue($result, 'the previous handler return value should propagate');
+        $this->assertSame([E_USER_WARNING, 'warn', '/y.php', 7], $previousArgs);
+    }
+
+    public function testToleranceHandlerReturnsFalseForOtherLevelsWhenNoPreviousHandler(): void
+    {
+        $handler = (new Module())->makeToleranceHandler(null);
+
+        $this->assertFalse(
+            $handler(E_USER_WARNING, 'warn', '/z.php', 1),
+            'with no previous handler, non-E_USER_ERROR levels fall through to PHP (return false)'
+        );
     }
 }


### PR DESCRIPTION
## Description

Log occurrences with a triage tag and continue execution, restoring the pre-monolog behaviour.

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
